### PR TITLE
Add index page to solve Dash "File is directory" error.

### DIFF
--- a/dashing.json
+++ b/dashing.json
@@ -11,5 +11,6 @@
     },
     "ignore": ["image Package Reference Manual"],
     "allowJS": true,
-    "icon32x32": "icon.png"
+    "icon32x32": "icon.png",
+    "index": "torch7-index.html"
 }


### PR DESCRIPTION
Without this dashing creates an empty dashIndexFilePath entry, that causes dash to show the error message "File is directory".

This fix is a little crude, but it does the job. I've also reported this to Kapeli who says that he's gonna update dash to handle this a little better.
